### PR TITLE
ci: extract version property for surefire plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kafka.version>3.6.1</kafka.version>
         <kafka.scala.version>2.13</kafka.scala.version>
+        <maven-surefire.version>3.2.3</maven-surefire.version>
     </properties>
 
     <dependencies>
@@ -109,13 +110,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>${maven-surefire.version}</version>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>${maven-surefire.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
To avoid double PRs everytime a new surefire (and failsafe) is released.