### PR TITLE
feat: make LDAP timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ authz.ldap.host=openldap
 authz.ldap.port=389
 authz.ldap.base.dn=dc=example,dc=com
 authz.ldap.username.to.dn.format=cn=%s,ou=People,dc=example,dc=com
+authz.ldap.timeout.ms=5000
 ```
+
+`authz.ldap.timeout.ms` is optional and defaults to 5000 (5 seconds).
 
 LDAPS (TLS) is assumed if the port is 636. For all other ports,
 plain-text LDAP is assumed. If using LDAPS with a self-signed

--- a/src/main/java/io/statnett/k3a/authz/ldap/LdapAuthenticateCallbackHandler.java
+++ b/src/main/java/io/statnett/k3a/authz/ldap/LdapAuthenticateCallbackHandler.java
@@ -24,6 +24,7 @@ implements AuthenticateCallbackHandler {
     private static final String CONFIG_LDAP_BASE_DN = "authz.ldap.base.dn";
     private static final String CONFIG_LDAP_USER_DN = "authz.ldap.user.dn";
     private static final String CONFIG_LDAP_USER_PASSWORD = "authz.ldap.user.password";
+    private static final String CONFIG_LDAP_TIMEOUT_MS = "authz.ldap.timeout.ms";
     private static final String CONFIG_LDAP_USERNAME_TO_DN_FORMAT = "authz.ldap.username.to.dn.format";
     private static final String CONFIG_LDAP_USERNAME_TO_UNIQUE_SEARCH_FORMAT = "authz.ldap.username.to.unique.search.format";
     private static final String SASL_PLAIN = "PLAIN";
@@ -53,18 +54,24 @@ implements AuthenticateCallbackHandler {
     }
 
     private void configure(final Map<String, ?> configs) {
-        final String host = getRequiredStringProperty(configs, CONFIG_LDAP_HOST);
-        final int port = getRequiredIntProperty(configs, CONFIG_LDAP_PORT);
-        final String baseDn = getRequiredStringProperty(configs, CONFIG_LDAP_BASE_DN);
+        final LdapConnectionSpec connectionSpec = toLdapConnectionSpec(configs);
         final String usernameToDnFormat = getRequiredStringProperty(configs, CONFIG_LDAP_USERNAME_TO_DN_FORMAT);
         final String usernameToUniqueSearchFormat = getStringProperty(configs, CONFIG_LDAP_USERNAME_TO_UNIQUE_SEARCH_FORMAT);
         final String userDn = getStringProperty(configs, CONFIG_LDAP_USER_DN);
         final String userPassword = getStringProperty(configs, CONFIG_LDAP_USER_PASSWORD);
-        authenticator = usernamePasswordAuthenticatorFactory.create(new LdapConnectionSpec(host, port, port == 636, baseDn), usernameToDnFormat, usernameToUniqueSearchFormat, userDn, userPassword);
+        authenticator = usernamePasswordAuthenticatorFactory.create(connectionSpec, usernameToDnFormat, usernameToUniqueSearchFormat, userDn, userPassword);
         LOG.info("Configured.");
     }
 
-    private int getRequiredIntProperty(final Map<String, ?> configs, final String name) {
+    static LdapConnectionSpec toLdapConnectionSpec(final Map<String, ?> configs) {
+        final String host = getRequiredStringProperty(configs, CONFIG_LDAP_HOST);
+        final int port = getRequiredIntProperty(configs, CONFIG_LDAP_PORT);
+        final String baseDn = getRequiredStringProperty(configs, CONFIG_LDAP_BASE_DN);
+        final int timeoutMs = getIntProperty(configs, CONFIG_LDAP_TIMEOUT_MS, LdapConnectionSpec.DEFAULT_TIMEOUT_MS);
+        return new LdapConnectionSpec(host, port, port == 636, baseDn, timeoutMs);
+    }
+
+    private static int getRequiredIntProperty(final Map<String, ?> configs, final String name) {
         final String stringValue = getRequiredStringProperty(configs, name);
         try {
             return Integer.parseInt(stringValue);
@@ -73,12 +80,24 @@ implements AuthenticateCallbackHandler {
         }
     }
 
-    private String getStringProperty(final Map<String, ?> configs, final String name) {
+    private static int getIntProperty(final Map<String, ?> configs, final String name, final int defaultValue) {
+        final String stringValue = getStringProperty(configs, name);
+        if (stringValue == null) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(stringValue);
+        } catch (final NumberFormatException e) {
+            throw new IllegalArgumentException("Value must be numeric in configuration property \"" + name + "\".");
+        }
+    }
+
+    private static String getStringProperty(final Map<String, ?> configs, final String name) {
         final Object value = configs.get(name);
         return value == null ? null : value.toString();
     }
 
-    private String getRequiredStringProperty(final Map<String, ?> configs, final String name) {
+    private static String getRequiredStringProperty(final Map<String, ?> configs, final String name) {
         final Object value = configs.get(name);
         if (value == null) {
             throw new IllegalArgumentException("Missing required configuration property \"" + name + "\".");

--- a/src/main/java/io/statnett/k3a/authz/ldap/utils/LdapConnectionSpec.java
+++ b/src/main/java/io/statnett/k3a/authz/ldap/utils/LdapConnectionSpec.java
@@ -2,20 +2,31 @@ package io.statnett.k3a.authz.ldap.utils;
 
 public final class LdapConnectionSpec {
 
+    public static final int DEFAULT_TIMEOUT_MS = 5000;
     private final String server;
     private final int port;
     private final boolean useTls;
     private final String baseDn;
+    private final int timeoutMs;
 
     public LdapConnectionSpec(final String server, final int port, final boolean useTls, final String baseDn) {
+        this(server, port, useTls, baseDn, DEFAULT_TIMEOUT_MS);
+    }
+
+    public LdapConnectionSpec(final String server, final int port, final boolean useTls, final String baseDn, final int timeoutMs) {
         this.server = server;
         this.port = port;
         this.useTls = useTls;
         this.baseDn = baseDn;
+        this.timeoutMs = timeoutMs;
     }
 
     public String getUrl() {
         return (useTls ? "ldaps" : "ldap") + "://" + server + ":" + port + "/" + baseDn;
+    }
+
+    public int getTimeoutMs() {
+        return timeoutMs;
     }
 
 }

--- a/src/main/java/io/statnett/k3a/authz/ldap/utils/LdapUtils.java
+++ b/src/main/java/io/statnett/k3a/authz/ldap/utils/LdapUtils.java
@@ -74,8 +74,9 @@ public final class LdapUtils {
         /* As per https://docs.oracle.com/javase/jndi/tutorial/ldap/connect/pool.html,
          * not using connection pooling, since we change the principal of the connection. */
         env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
-        env.put("com.sun.jndi.ldap.read.timeout", "5000");
-        env.put("com.sun.jndi.ldap.connect.timeout", "5000");
+        final String timeoutMsString = String.valueOf(ldapConnectionSpec.getTimeoutMs());
+        env.put("com.sun.jndi.ldap.read.timeout", timeoutMsString);
+        env.put("com.sun.jndi.ldap.connect.timeout", timeoutMsString);
         env.put(Context.PROVIDER_URL, ldapConnectionSpec.getUrl());
         env.put(Context.SECURITY_AUTHENTICATION, "simple");
         env.put(Context.SECURITY_PRINCIPAL, userDn);

--- a/src/test/java/io/statnett/k3a/authz/ldap/LdapAuthenticateCallbackHandlerTest.java
+++ b/src/test/java/io/statnett/k3a/authz/ldap/LdapAuthenticateCallbackHandlerTest.java
@@ -1,5 +1,6 @@
 package io.statnett.k3a.authz.ldap;
 
+import io.statnett.k3a.authz.ldap.utils.LdapConnectionSpec;
 import io.statnett.k3a.authz.ldap.utils.UsernamePasswordAuthenticator;
 import org.apache.kafka.common.security.plain.PlainAuthenticateCallback;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -146,6 +148,21 @@ public final class LdapAuthenticateCallbackHandlerTest {
             throw new RuntimeException("Got unexpected exception.", e);
         }
         kafkaDestroyCallbackHandler(callbackHandler);
+    }
+
+    @Test
+    public void shouldHaveDefaultTimeoutWhenNotGiven() {
+        final Map<String, Object> configs = getWorkingConfigs();
+        final LdapConnectionSpec connectionSpec = LdapAuthenticateCallbackHandler.toLdapConnectionSpec(configs);
+        assertEquals(LdapConnectionSpec.DEFAULT_TIMEOUT_MS, connectionSpec.getTimeoutMs());
+    }
+
+    @Test
+    public void shouldOverrideDefaultTimeoutWhenGiven() {
+        final Map<String, Object> configs = getWorkingConfigs();
+        configs.put("authz.ldap.timeout.ms", 6000);
+        final LdapConnectionSpec connectionSpec = LdapAuthenticateCallbackHandler.toLdapConnectionSpec(configs);
+        assertEquals(6000, connectionSpec.getTimeoutMs());
     }
 
     private Callback getUsernameCallback(final String username) {


### PR DESCRIPTION
Closes https://github.com/statnett/k3a-ldap-authenticator/issues/200

Adds configuration option `authz.ldap.timeout.ms` that allows the user to specify LDAP connection and read timeout. If not given, defaults to the old value of 5000 milliseconds.